### PR TITLE
newBlock.uid fallback to clientId

### DIFF
--- a/assets/js/block-save/block-save.js
+++ b/assets/js/block-save/block-save.js
@@ -83,7 +83,7 @@ export class SaveBlock {
     for ( let block of blocks ) {
       let blockName = block.name.replace( '/', '-' );
       newBlocks.push({
-        uid: block.uid,
+        uid: block.uid || block.clientId,
         name: block.name,
         data: wp.hooks.applyFilters( `clean_data_${blockName}`, block.attributes, block.name, block.innerBlocks )
       })


### PR DESCRIPTION
Some blocks do not have a `block.uid`, this will ensure a unique id per block on save.