### PR TITLE
Update Gutenberg block parser function name

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -243,7 +243,7 @@ class API {
 	 */
 	public function get_revision_data( \WP_REST_Request $request ) {
 
-		if ( ! function_exists( 'gutenberg_parse_blocks' ) ) {
+		if ( ! function_exists( 'parse_blocks' ) ) {
 			return new \WP_Error( 'no gutes', __( 'No Gutes do_blocks' ) );
 		}
 
@@ -253,7 +253,7 @@ class API {
 		$data['revisions'] = wp_get_post_revisions( $post_id );
 
 		foreach( $data['revisions'] as $key => $value ) {
-			$data['revisions'][$key]->editor_blocks = gutenberg_parse_blocks( $value->post_content );
+			$data['revisions'][$key]->editor_blocks = parse_blocks( $value->post_content );
 		}
 
 


### PR DESCRIPTION
Update from `gutenberg_parse_blocks()` to `parse_blocks()`

Function was renamed in a 5.x update to deprecate `gutenberg_` prefix functions; noticed the problem when accessing revision data via `/wp-json/gutes-db/v1/{id}/revisions`

Further reading:
https://github.com/WordPress/gutenberg/issues/12653
[Gutenberg deprecation list](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/backward-compatibility/deprecations.md#520)
