### PR TITLE
Feat: store preview data into own table

### DIFF
--- a/assets/js/block-save/block-save.js
+++ b/assets/js/block-save/block-save.js
@@ -56,7 +56,8 @@ export class SaveBlock {
         path: '/gutes-db/v1/' + postId,
         data: {
           post_id: postId,
-          gutes_data: blocks_dup.length ? JSON.stringify( blocks_dup ) : false
+          gutes_data: blocks_dup.length ? JSON.stringify( blocks_dup ) : false,
+          is_in_preview: editor.isPreviewingPost(),
         },
         method: 'POST',
         dataType: 'json',

--- a/src/Database.php
+++ b/src/Database.php
@@ -8,6 +8,11 @@ use GutesObjectPlugin\GutesObjectPlugin;
 class Database {
 
 	public function create() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . "gutes_arrays";
+		$table_name_preview = $wpdb->prefix . "gutes_arrays_preview";
+
 		register_activation_hook( GutesObjectPlugin::$GutesObjectPluginFile, [ $this, 'activate_gutes_array_save' ] );
 		register_deactivation_hook( GutesObjectPlugin::$GutesObjectPluginFile, [ $this, 'deactivate_gutes_array_save' ] );
 	}
@@ -15,6 +20,23 @@ class Database {
 	public function activate_gutes_array_save() {
 		global $wpdb;
 		$table_name = $wpdb->prefix . "gutes_arrays";
+		$table_name_preview = $wpdb->prefix . "gutes_arrays_preview";
+
+		$this->create_table( $table_name );
+		$this->create_table( $table_name_preview );
+	}
+
+	public function deactivate_gutes_array_save() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . "gutes_arrays";
+		$table_name_preview = $wpdb->prefix . "gutes_arrays_preview";
+
+		$this->drop_table( $table_name );
+		$this->drop_table( $table_name_preview );
+	}
+
+	private function create_table( $table_name ) {
+		global $wpdb;
 		$charset_collate = $wpdb->get_charset_collate();
 		$sql = "CREATE TABLE $table_name (
                     id mediumint(9) NOT NULL AUTO_INCREMENT,
@@ -27,9 +49,9 @@ class Database {
 		dbDelta( $sql );
 	}
 
-	public function deactivate_gutes_array_save() {
+	private function drop_table( $table_name ) {
 		global $wpdb;
-		$table_name = $wpdb->prefix . "gutes_arrays";
+
 		$charset_collate = $wpdb->get_charset_collate();
 		$sql = "DROP TABLE $table_name";
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -41,7 +41,7 @@ class Hooks {
 			return false;
 		}
 
-		$gutes_data = $this->api->get_editor_db( $post->ID );
+		$gutes_data = $this->api->get_editor_db( $post->ID, $_GET["preview"] == "true", false );
 		if ( ! is_object( $gutes_data ) ) {
 			return 'Error Getting Editor DB ' . $post->ID;
 		}


### PR DESCRIPTION
This stores all the data into an own table `gutes_array_preview`. This row exists until the post has been saved (it autodeletes on an "Update").

**Current behavior:**
When you press on "preview" then the data automatically overwrites the old data, which is not wanted, as it breaks the "preview" behavior.

**This PRs behavior:**
When you press on "preview" then the data does not overwrite the old data but stores the value in an own table. The preview data can be accessed via the api and a `?preview=true` GET parameter. When you press on "update" the preview data gets removed and everything gets back to normal (the data got saved as usual)